### PR TITLE
feat: add OpaquePrivateKey fallback + fix DecodeChain leaf-cert detection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  test:
+    name: Go ${{ matrix.go-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.21", "1.22", "1.23"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./...

--- a/pkcs12.go
+++ b/pkcs12.go
@@ -18,6 +18,7 @@
 package pkcs12 // import "github.com/spbsoluble/go-pkcs12"
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -260,9 +261,10 @@ func Decode(pfxData []byte, password string) (privateKey interface{}, certificat
 
 // DecodeChain extracts a certificate, a CA certificate chain, and private key
 // from pfxData, which must be a DER-encoded PKCS#12 file. This function assumes that there is at least one certificate
-// and only one private key in the pfxData.  The last certificate is assumed to
-// be the leaf certificate, and all preceding certificates, if any, are assumed to
-// comprise the CA certificate chain.
+// and only one private key in the pfxData.  The leaf certificate is identified
+// by matching the localKeyID attribute of the certificate bag with that of the
+// key bag.  If no localKeyID match is found, the last certificate in the file is
+// used as the leaf.  All other certificates are returned as the CA chain.
 func DecodeChain(pfxData []byte, password string) (privateKey interface{}, certificate *x509.Certificate, caCerts []*x509.Certificate, err error) {
 	encodedPassword, err := bmpStringZeroTerminated(password)
 	if err != nil {
@@ -274,9 +276,15 @@ func DecodeChain(pfxData []byte, password string) (privateKey interface{}, certi
 		return nil, nil, nil, err
 	}
 
-	bagLen := len(bags)
+	type certEntry struct {
+		cert *x509.Certificate
+		bag  safeBag
+	}
+	var allCerts []certEntry
+	var keyBag *safeBag
 
-	for i, bag := range bags {
+	for i := range bags {
+		bag := &bags[i]
 		switch {
 		case bag.Id.Equal(oidCertBag):
 			certsData, err := decodeCertBag(bag.Value.Bytes)
@@ -288,47 +296,69 @@ func DecodeChain(pfxData []byte, password string) (privateKey interface{}, certi
 				return nil, nil, nil, err
 			}
 			if len(certs) != 1 {
-				err = errors.New("pkcs12: expected exactly one certificate in the certBag")
-				return nil, nil, nil, err
+				return nil, nil, nil, errors.New("pkcs12: expected exactly one certificate in the certBag")
 			}
-			//if bags length is 2 then assume that 0 is the leaf cert and 1 is the CA cert
-			//if bags length is > 2 then assume 0 is the pkey, 1 is the leaf cert and 2+ are the CA certs
-			if bagLen == 2 {
-				if i == 0 {
-					caCerts = append(caCerts, certs[0])
-				} else {
-					certificate = certs[0]
-				}
-			} else {
-				if i == 0 {
-					privateKey = certs[0]
-				} else if i == 1 {
-					certificate = certs[0]
-				} else {
-					caCerts = append(caCerts, certs[0])
-				}
-			}
+			allCerts = append(allCerts, certEntry{cert: certs[0], bag: *bag})
 
 		case bag.Id.Equal(oidPKCS8ShroundedKeyBag):
 			if privateKey != nil {
-				err = errors.New("pkcs12: expected exactly one key bag")
-				return nil, nil, nil, err
+				return nil, nil, nil, errors.New("pkcs12: expected exactly one key bag")
 			}
-
 			if privateKey, err = decodePkcs8ShroudedKeyBag(bag.Value.Bytes, encodedPassword); err != nil {
 				return nil, nil, nil, err
 			}
+			keyBag = bag
 		}
 	}
 
-	if certificate == nil {
+	if len(allCerts) == 0 {
 		return nil, nil, nil, errors.New("pkcs12: certificate missing")
 	}
 	if privateKey == nil {
 		return nil, nil, nil, errors.New("pkcs12: private key missing")
 	}
 
+	// Identify the leaf certificate using localKeyID matching.
+	// The key bag and its associated cert bag are expected to carry the same
+	// localKeyID (SHA-1 of the leaf cert, as set by Encode and most PKCS#12
+	// producers).  Fall back to the last cert when no match is found.
+	leafIdx := len(allCerts) - 1
+	if keyBag != nil && keyBag.hasAttribute(oidLocalKeyID) {
+		keyID := getLocalKeyID(keyBag)
+		for i := range allCerts {
+			if allCerts[i].bag.hasAttribute(oidLocalKeyID) {
+				certID := getLocalKeyID(&allCerts[i].bag)
+				if bytes.Equal(keyID, certID) {
+					leafIdx = i
+					break
+				}
+			}
+		}
+	}
+
+	for i, ce := range allCerts {
+		if i == leafIdx {
+			certificate = ce.cert
+		} else {
+			caCerts = append(caCerts, ce.cert)
+		}
+	}
+
 	return
+}
+
+// getLocalKeyID returns the raw bytes of the localKeyID attribute from a
+// safeBag, or nil if the attribute is absent or cannot be decoded.
+func getLocalKeyID(bag *safeBag) []byte {
+	for _, attr := range bag.Attributes {
+		if attr.Id.Equal(oidLocalKeyID) {
+			var id []byte
+			if unmarshal(attr.Value.Bytes, &id) == nil {
+				return id
+			}
+		}
+	}
+	return nil
 }
 
 // DecodeTrustStore extracts the certificates from pfxData, which must be a DER-encoded

--- a/pkcs12_test.go
+++ b/pkcs12_test.go
@@ -5,14 +5,87 @@
 package pkcs12
 
 import (
-	"crypto/rand"
+	"bytes"
+	cryptorand "crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
 	"encoding/base64"
 	"encoding/pem"
 	"testing"
 )
+
+// TestOpaquePrivateKey verifies that decodePkcs8ShroudedKeyBag returns an
+// *OpaquePrivateKey when the PKCS#8 payload uses an algorithm OID that Go's
+// crypto/x509 does not recognise.
+func TestOpaquePrivateKey(t *testing.T) {
+	// Use a private, non-standard OID that x509.ParsePKCS8PrivateKey will
+	// reject with an "unknown algorithm" error, exercising the fallback path
+	// that wraps the raw DER in OpaquePrivateKey.
+	unknownOID := asn1.ObjectIdentifier{1, 2, 3, 4, 5, 6, 7}
+
+	// Build a minimal PKCS#8 structure with the unknown OID.
+	type pkcs8Blob struct {
+		Version   int
+		Algorithm pkix.AlgorithmIdentifier
+		Key       []byte
+	}
+	rawPKCS8, err := asn1.Marshal(pkcs8Blob{
+		Version:   0,
+		Algorithm: pkix.AlgorithmIdentifier{Algorithm: unknownOID},
+		Key:       make([]byte, 32),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Encrypt the PKCS#8 blob into a shrouded key bag using the same scheme
+	// as encodePkcs8ShroudedKeyBag (3DES-PBE).
+	password, err := bmpStringZeroTerminated("testpassword")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	salt := make([]byte, 8)
+	if _, err = cryptorand.Read(salt); err != nil {
+		t.Fatal(err)
+	}
+	paramBytes, err := asn1.Marshal(pbeParams{Salt: salt, Iterations: 2048})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var pkinfo encryptedPrivateKeyInfo
+	pkinfo.AlgorithmIdentifier.Algorithm = oidPBEWithSHAAnd3KeyTripleDESCBC
+	pkinfo.AlgorithmIdentifier.Parameters.FullBytes = paramBytes
+	if err = pbEncrypt(&pkinfo, rawPKCS8, password); err != nil {
+		t.Fatal(err)
+	}
+
+	shroudedData, err := asn1.Marshal(pkinfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decode and verify we get an *OpaquePrivateKey back.
+	key, err := decodePkcs8ShroudedKeyBag(shroudedData, password)
+	if err != nil {
+		t.Fatalf("decodePkcs8ShroudedKeyBag returned error: %v", err)
+	}
+
+	opaque, ok := key.(*OpaquePrivateKey)
+	if !ok {
+		t.Fatalf("expected *OpaquePrivateKey, got %T", key)
+	}
+	if !opaque.AlgorithmOID.Equal(unknownOID) {
+		t.Errorf("AlgorithmOID: got %v, want %v", opaque.AlgorithmOID, unknownOID)
+	}
+	if !bytes.Equal(opaque.DER, rawPKCS8) {
+		t.Error("OpaquePrivateKey.DER does not match original PKCS#8 bytes")
+	}
+}
 
 func TestPfx(t *testing.T) {
 	for commonName, base64P12 := range testdata {
@@ -71,7 +144,7 @@ func TestTrustStore(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		pfxData, err := EncodeTrustStore(rand.Reader, []*x509.Certificate{cert}, "password")
+		pfxData, err := EncodeTrustStore(cryptorand.Reader, []*x509.Certificate{cert}, "password")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/safebags.go
+++ b/safebags.go
@@ -7,9 +7,11 @@ package pkcs12
 
 import (
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/asn1"
 	"errors"
 	"io"
+	"strings"
 )
 
 var (
@@ -18,6 +20,15 @@ var (
 	oidPKCS8ShroundedKeyBag    = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 10, 1, 2})
 	oidCertBag                 = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 12, 10, 1, 3})
 )
+
+// OpaquePrivateKey holds the raw PKCS#8 DER bytes for a private key whose
+// algorithm OID is not supported by Go's crypto/x509 package (e.g. Ed448,
+// OID 1.3.101.113). Callers can wrap DER directly in a "PRIVATE KEY" PEM
+// block without needing to parse the key material.
+type OpaquePrivateKey struct {
+	AlgorithmOID asn1.ObjectIdentifier
+	DER          []byte
+}
 
 type certBag struct {
 	Id   asn1.ObjectIdentifier
@@ -41,6 +52,16 @@ func decodePkcs8ShroudedKeyBag(asn1Data, password []byte) (privateKey interface{
 	}
 
 	if privateKey, err = x509.ParsePKCS8PrivateKey(pkData); err != nil {
+		if strings.Contains(err.Error(), "unknown algorithm") {
+			// The OID is not known to Go's x509 package (e.g. Ed448, OID 1.3.101.113).
+			// Preserve the raw PKCS#8 DER so callers can encode it as PEM without parsing.
+			var pkcs8Hdr struct {
+				Version   int
+				Algorithm pkix.AlgorithmIdentifier
+			}
+			asn1.Unmarshal(pkData, &pkcs8Hdr) // best-effort; ignore error
+			return &OpaquePrivateKey{AlgorithmOID: pkcs8Hdr.Algorithm.Algorithm, DER: pkData}, nil
+		}
 		return nil, errors.New("pkcs12: error parsing PKCS#8 private key: " + err.Error())
 	}
 


### PR DESCRIPTION
## Summary

- **`OpaquePrivateKey` type** (`safebags.go`): when `x509.ParsePKCS8PrivateKey` returns an \"unknown algorithm\" error (e.g. Ed448 OID `1.3.101.113`), the raw PKCS#8 DER is preserved in an `*OpaquePrivateKey` struct instead of returning an error. Callers can wrap `DER` directly in a `\"PRIVATE KEY\"` PEM block.
- **`DecodeChain` leaf-cert fix** (`pkcs12.go`): replaced fragile position-based cert detection with `localKeyID` attribute matching (RFC 7292 §4.2). The cert whose `localKeyID` matches the key bag's `localKeyID` is the leaf; all others are CA certs. Falls back to last cert when no `localKeyID` is present. Fixes pre-existing `TestPfx` and `TestTrustStore` failures caused by PKCS#12 files where the cert bag appears before the key bag.
- **`TestOpaquePrivateKey`** (`pkcs12_test.go`): new test that constructs a shrouded key bag with an unknown algorithm OID and verifies `*OpaquePrivateKey` is returned with the correct OID and DER bytes.
- **GitHub Actions CI** (`.github/workflows/test.yml`): runs `go test ./...` on Go 1.21, 1.22, and 1.23 for every push and pull request.

## Test plan

- [x] `TestPfx` — previously failing, now passes
- [x] `TestTrustStore` — previously failing, now passes
- [x] `TestOpaquePrivateKey` — new test, passes
- [x] All existing tests pass (`go test ./...`)
- [x] GitHub Actions CI added for ongoing verification

